### PR TITLE
Fix Titlebar all White Bug

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -14,7 +14,6 @@ void darkMode(QApplication& rApp)
     dark_pal.setColor(QPalette::ToolTipText, QColorConstants::White);
     dark_pal.setColor(QPalette::Text, QColorConstants::White);
     dark_pal.setColor(QPalette::Button, QColor(17, 149, 79));
-    dark_pal.setColor(QPalette::ButtonText, QColorConstants::White);
     dark_pal.setColor(QPalette::BrightText, QColorConstants::Red);
     dark_pal.setColor(QPalette::Link, QColor(42, 130, 218));
     dark_pal.setColor(QPalette::Highlight, QColor(42, 130, 218));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -18,9 +18,9 @@ MainWindow::MainWindow(QWidget *parent)
     , ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
-    ui->saveButton->setStyleSheet("background-color : rgb(87,87,87); border: 1px solid grey; border-radius: 4px");
-    ui->saveAsButton->setStyleSheet("background-color : rgb(87,87,87); border: 1px solid grey; border-radius: 4px");
-    ui->manualButton->setStyleSheet("background-color : rgb(87,87,87); border: 1px solid grey; border-radius: 4px");
+    ui->saveButton->setStyleSheet("background-color: rgb(87,87,87); color: white; border: 1px solid grey; border-radius: 4px");
+    ui->saveAsButton->setStyleSheet("background-color: rgb(87,87,87); color: white; border: 1px solid grey; border-radius: 4px");
+    ui->manualButton->setStyleSheet("background-color: rgb(87,87,87); color: white; border: 1px solid grey; border-radius: 4px");
     connect(ui->saveButton, &QPushButton::pressed, this, &MainWindow::writeNewFiles);
     connect(ui->saveAsButton, &QPushButton::pressed, this, &MainWindow::writeNewFiles);
     connect(ui->manualButton, &QPushButton::pressed, this, &MainWindow::launchManualEditor);


### PR DESCRIPTION
When you set the button text color palette Qt will also use that color for the titlebar, this is bad as it can render it useless depending on the toolbar API for OS. So I removed the blanket white color for all buttons and used QSS to color the specific buttons. Could add QSS string vars for buttons